### PR TITLE
Oneof support

### DIFF
--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -44,13 +44,28 @@
           attribute[0] = "#{key}:#{attribute[0]}"
         end
         attributes.concat(nested)
+
       # found an array with nested objects
-      elsif value['items'] && value['items']['properties']
-        nested = extract_attributes(schema, value['items']['properties'])
-        nested.each do |attribute|
-          attribute[0] = "#{key}/#{attribute[0]}"
+      elsif value['items'] 
+        if value['items']['properties']
+          nested = extract_attributes(schema, value['items']['properties'])
+          nested.each do |attribute|
+            attribute[0] = "#{key}/#{attribute[0]}"
+          end
+          attributes.concat(nested)
         end
-        attributes.concat(nested)
+        if value['items']['oneOf']
+          value['items']['oneOf'].each_with_index do |oneof, index|
+          ref,  oneof_definition = schema.dereference(oneof)
+          oneof_name = ref ? ref.split('/').last : index
+          nested = extract_attributes(schema, oneof_definition['properties'])
+          nested.each do |attribute|
+            attribute[0] = "#{key}/#{attribute[0]}[#{oneof_name.upcase}]"
+          end
+          attributes.concat(nested)
+        end
+      end
+
       # just a regular attribute
       else
         attributes << build_attribute(schema, key, value)

--- a/lib/prmd/templates/schemata/helper.erb
+++ b/lib/prmd/templates/schemata/helper.erb
@@ -60,7 +60,7 @@
           oneof_name = ref ? ref.split('/').last : index
           nested = extract_attributes(schema, oneof_definition['properties'])
           nested.each do |attribute|
-            attribute[0] = "#{key}/#{attribute[0]}[#{oneof_name.upcase}]"
+            attribute[0] = "#{key}/[#{oneof_name.upcase}].#{attribute[0]}"
           end
           attributes.concat(nested)
         end

--- a/test/commands/render_test.rb
+++ b/test/commands/render_test.rb
@@ -20,10 +20,19 @@ class InteragentRenderTest < Minitest::Test
         }
       }
     })
-
     markdown = render
     assert_match /version.*v10\.9\.rc1/, markdown
   end
+
+
+  def test_render_for_schema_with_property_defined_with_oneOf
+    markdown = render
+
+   assert_match /\*\*options\/type\[OPTION1\]\*\*/, markdown
+   assert_match /\*\*options\/type\[OPTION2\]\*\*/, markdown
+  end
+
+
 
   def test_render_for_example_as_an_array
     # matches -d '[{...}]' taking into account line breaks and spacing
@@ -85,6 +94,43 @@ class InteragentRenderTest < Minitest::Test
               'type'        => 'string',
               'example'     => 'example'
             },
+            'option-type1' => {
+              'type' => 'string', 
+              'example' => 'OPTION1', 
+              'enum' => 'OPTION1'                   
+            },
+            'option-type2' => {
+              'type' => 'string', 
+              'example' => 'OPTION2',
+              'enum' => 'OPTION2'
+            },
+            'option1' => {
+              'properties' => {
+                'type' => {
+                    '$ref' => '#/definitions/config-var/definitions/option-type1'    
+                }
+              }
+            },
+            'option2' => {
+              'properties' => {
+                'type' => {
+                    '$ref' => '#/definitions/config-var/definitions/option-type2'    
+                }
+              }
+            },
+            'options' => {                      
+              'items' => {
+                'example'=> 'CHOICE1',
+                'oneOf' => [
+                  { 
+                    '$ref' => '#/definitions/config-var/definitions/option1'
+                  },
+                  { 
+                   '$ref' => '#/definitions/config-var/definitions/option2'
+                  }
+                ]
+              }
+            }
           },
           'links' => [
             {
@@ -117,6 +163,9 @@ class InteragentRenderTest < Minitest::Test
             },
             'value' => {
               '$ref' => '#/definitions/config-var/definitions/value'
+            },
+            'options' => {
+              '$ref' => '#/definitions/config-var/definitions/options'
             }
           }
         }

--- a/test/commands/render_test.rb
+++ b/test/commands/render_test.rb
@@ -28,8 +28,8 @@ class InteragentRenderTest < Minitest::Test
   def test_render_for_schema_with_property_defined_with_oneOf
     markdown = render
 
-   assert_match /\*\*options\/type\[OPTION1\]\*\*/, markdown
-   assert_match /\*\*options\/type\[OPTION2\]\*\*/, markdown
+   assert_match /\*\*options\/\[OPTION1\]\.type\*\*/, markdown
+   assert_match /\*\*options\/\[OPTION2\]\.type\*\*/, markdown
   end
 
 


### PR DESCRIPTION
This branch adds oneOf support to prmd in order to support generating the tender changes to core-api as seen in this comment shopkeep/core-api#492 (comment).
